### PR TITLE
fix typos in English language strings

### DIFF
--- a/lang/en/report_trainingsessions.php
+++ b/lang/en/report_trainingsessions.php
@@ -324,7 +324,7 @@ Example :
 
 $string['lineaggregators_help'] = '
 <p>Define aggregators as a list of aggregators switches starting from left most columns in the
-resulting excel sheet. Separe switches with comas or semicolumns. Leaving blank disables the
+resulting excel sheet. Separate switches with comas or semicolons. Leaving blank disables the
 aggregator line.
 </p>
 <ul>
@@ -333,7 +333,7 @@ aggregator line.
 </ul>
 
 <p>
-Example : if an excel output has 10 colums and a sum is required on column 10, than
+Example : if an excel output has 10 colums and a sum is required on column 10, then
 enter : ;;;;;;;;;s
 </p>';
 


### PR DESCRIPTION
Hi,
I think there are a couple of minor typos in the newer English language strings for this plugin.